### PR TITLE
Make svg full width

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -275,7 +275,7 @@ if ($bgcolors eq "yellow") {
 		$self->{svg} .= <<SVG;
 <?xml version="1.0"$enc_attr standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" width="$w" height="$h" onload="init(evt)" viewBox="0 0 $w $h" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg version="1.1" width="100%" height="$h" preserveAspectRatio="none" onload="init(evt)" viewBox="0 0 $w $h" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
 <!-- NOTES: $notestext -->
 SVG


### PR DESCRIPTION
This sets the width to `100%` and sets `preserveAspectRatio="none"` on the image. Because of [this issue](https://stackoverflow.com/questions/29117299/preserve-aspect-ratio-for-svg-text), the text looks bad if the aspect ratio changes too much, so we are keeping the 1900 width default, so the underlying viewport has a more fitting aspect ratio